### PR TITLE
Adds support for filename aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ workbox:
   precache_glob_patterns: # Optional
     - "{js,css,fonts}/**/*.{js,css,eot,svg,ttf,woff}"
     - index.html
-    - about.html: # This entry aliases about/ and contact/ to about.html
+    - "about.html": # This entry aliases about/ and contact/ to about.html
         - about/
         - contact/
   precache_glob_ignores: # Optional

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ workbox:
   precache_glob_patterns: # Optional
     - "{js,css,fonts}/**/*.{js,css,eot,svg,ttf,woff}"
     - index.html
+    - about.html: # This entry aliases about/ and contact/ to about.html
+        - about/
+        - contact/
   precache_glob_ignores: # Optional
     - "fonts/**/*"
 ```
@@ -66,7 +69,7 @@ Parameter                 | Description
 sw_src_filepath           | Filepath of the source service worker. Defaults to `sw.js`
 sw_dest_filename          | Filename of the destination service worker. Defaults to `sw.js`
 precache_glob_directory   | Directory of precache. [Workbox Config](https://developers.google.com/web/tools/workbox/get-started/webpack#optional-config)
-precache_glob_patterns    | Patterns of precache. [Workbox Config](https://developers.google.com/web/tools/workbox/get-started/webpack#optional-config)
+precache_glob_patterns    | Patterns of precache. Accepts aliased names pointing to the same file to support pretty permalinks [Workbox Config](https://developers.google.com/web/tools/workbox/get-started/webpack#optional-config)
 precache_glob_ignores     | Ignores of precache. [Workbox Config](https://developers.google.com/web/tools/workbox/get-started/webpack#optional-config)
 precache_recent_posts_num | Number of recent posts to precache.
 

--- a/jekyll-workbox-plugin.gemspec
+++ b/jekyll-workbox-plugin.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'jekyll-workbox-plugin'
-  s.version     = '0.0.1'
-  s.date        = '2018-12-06'
+  s.version     = '0.0.2'
+  s.date        = '2019-01-19'
   s.summary     = 'Workbox support for Jekyll.'
   s.description = 'This plugin provides workbox support for Jekyll. Generate a service worker and provides precache with Google Workbox.'
   s.authors     = ['Benedikt Meurer']


### PR DESCRIPTION
# Motivation
I'm using this plugin on https://dylangattey.com (and it's great!). But I realized I was getting some cache misses with my service worker. Taking a look, I precache the files `https://dylangattey.com/about.html` and `https://dylangattey.com/index.html` at the routes `https://dylangattey.com/about.html` and `https://dylangattey.com/index.html`. But that's wrong. With pretty URL rewrites, those URLs will never be hit in production, since I've rewritten all URLs to take off the `index.html`. This is pretty common.

Instead, I'd ideally want the file `https://dylangattey.com/index.html` cached under the key `https://dylangattey.com/`, and `https://dylangattey.com/about.html` under the key `https://dylangattey.com/about/`. This PR makes that possible!

# Implementation
I converted all filenames to a map of filename => file alias and propagated that throughout so that the plugin can easily work with aliases. I also added support for multiple aliases for the same file. Here's a demo of the config to make this work:
```yaml
workbox:
  precache_recent_posts_num: 5
  precache_glob_directory: /
  precache_glob_patterns:
    - 'index.html': ['/', 'projects/']  # Notice the multiple aliases here
    - 'about/index.html': about/        # Just one alias here
    - /404.html                         # This is the default, it still works
    - /offline/index.html
```
Note that ignore directives don't use aliases, but they will delete all aliases for a particular filepath if it exists.

## Docs
I also updated the README to mention this new case and gemspec so that a new gem can be easily published.